### PR TITLE
Remove unnecessary usages of Google Guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,11 +70,6 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.21</version>
@@ -114,6 +109,12 @@
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>0.9.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
A small library like this shouldn't depend on a large (standard) library which is notorious to update, such as Google Guava.

This PR moves Guava into `test` scope so that its classes can be used for convenience.