### PR TITLE
Properly support escaping backslashes in CEF message

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ import com.github.jcustenborder.cef.Message;
 class Foo {
   static void main(String... args) throws Exception {
     CEFParser f = CEFParserFactory.create();
-    Message message = f.parse("Sep 19 08:26:10 host CEF:0|security|threatmanager|1.0|100|detected a \| in message|10|src=10.0.0.1 act=blocked a | dst=1.1.1.1");
+    Message message = f.parse("Sep 19 08:26:10 host CEF:0|security|threatmanager|1.0|100|detected a \\| in message|10|src=10.0.0.1 act=blocked a | dst=1.1.1.1");
   }
 }
 ```

--- a/src/main/java/com/github/jcustenborder/cef/CEFParserImpl.java
+++ b/src/main/java/com/github/jcustenborder/cef/CEFParserImpl.java
@@ -136,7 +136,9 @@ class CEFParserImpl implements CEFParser {
 
 
     for (String token : parts) {
-      token = token.replace("\\|", "|");
+      token = token
+          .replace("\\\\", "\\")
+          .replace("\\|", "|");
       log.trace("parse() - index={}, token='{}'", index, token);
 
       switch (index) {
@@ -176,6 +178,7 @@ class CEFParserImpl implements CEFParser {
 
     final List<String> extensionParts = parts.subList(7, parts.size());
     final String extension = Joiner.on('|').join(extensionParts)
+        .replace("\\\\", "\\")
         .replace("\\n", "\n")
         .replace("\\=", "=");
     log.trace("parse() - extension = '{}'", extension);

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message0002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message0002.json
@@ -1,5 +1,5 @@
 {
-  "input": "CEF:0|security|threatmanager|1.0|100|detected a \\ in packet|10|src=10.0.0.1 act=blocked a \\ dst=1.1.1.1",
+  "input": "CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
   "expected": {
     "cefVersion": 0,
     "deviceVendor": "security",

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message1002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message1002.json
@@ -1,5 +1,5 @@
 {
-  "input" : "1493738863000 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\ in packet|10|src=10.0.0.1 act=blocked a \\ dst=1.1.1.1",
+  "input" : "1493738863000 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
   "expected" : {
     "timestamp" : 1493738863000,
     "host" : "hostname.example.com",

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message2002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message2002.json
@@ -1,5 +1,5 @@
 {
-  "input" : "May 02 15:27:43.000 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\ in packet|10|src=10.0.0.1 act=blocked a \\ dst=1.1.1.1",
+  "input" : "May 02 15:27:43.000 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
   "expected" : {
     "timestamp" : 1493738863000,
     "host" : "hostname.example.com",

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message3002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message3002.json
@@ -1,5 +1,5 @@
 {
-  "input" : "May 02 15:27:43.000 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\ in packet|10|src=10.0.0.1 act=blocked a \\ dst=1.1.1.1",
+  "input" : "May 02 15:27:43.000 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
   "expected" : {
     "timestamp" : 1493738863000,
     "host" : "hostname.example.com",

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message4002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message4002.json
@@ -1,5 +1,5 @@
 {
-  "input" : "May 02 15:27:43 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\ in packet|10|src=10.0.0.1 act=blocked a \\ dst=1.1.1.1",
+  "input" : "May 02 15:27:43 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
   "expected" : {
     "timestamp" : 1493738863000,
     "host" : "hostname.example.com",

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message5002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message5002.json
@@ -1,5 +1,5 @@
 {
-  "input" : "May 02 15:27:43 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\ in packet|10|src=10.0.0.1 act=blocked a \\ dst=1.1.1.1",
+  "input" : "May 02 15:27:43 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
   "expected" : {
     "timestamp" : 1493738863000,
     "host" : "hostname.example.com",

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message6002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message6002.json
@@ -1,5 +1,5 @@
 {
-  "input" : "May 02 2017 15:27:43.000 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\ in packet|10|src=10.0.0.1 act=blocked a \\ dst=1.1.1.1",
+  "input" : "May 02 2017 15:27:43.000 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
   "expected" : {
     "timestamp" : 1493738863000,
     "host" : "hostname.example.com",

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message7002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message7002.json
@@ -1,5 +1,5 @@
 {
-  "input" : "May 02 2017 15:27:43.000 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\ in packet|10|src=10.0.0.1 act=blocked a \\ dst=1.1.1.1",
+  "input" : "May 02 2017 15:27:43.000 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
   "expected" : {
     "timestamp" : 1493738863000,
     "host" : "hostname.example.com",

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message8002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message8002.json
@@ -1,5 +1,5 @@
 {
-  "input" : "May 02 2017 15:27:43 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\ in packet|10|src=10.0.0.1 act=blocked a \\ dst=1.1.1.1",
+  "input" : "May 02 2017 15:27:43 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
   "expected" : {
     "timestamp" : 1493738863000,
     "host" : "hostname.example.com",

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message9002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message9002.json
@@ -1,5 +1,5 @@
 {
-  "input" : "May 02 2017 15:27:43 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\ in packet|10|src=10.0.0.1 act=blocked a \\ dst=1.1.1.1",
+  "input" : "May 02 2017 15:27:43 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
   "expected" : {
     "timestamp" : 1493738863000,
     "host" : "hostname.example.com",


### PR DESCRIPTION
The ArcSight Common Event Format (CEF) specification version 24 says:

> If a backslash (\) is used in the header or the extension, it has to be escaped with another backslash (\). For example:
>
> Sep 19 08:26:10 host CEF:0|security|threatmanager|1.0|100|detected a \\ in packet|10|src=10.0.0.1 act=blocked a \\ dst=1.1.1.1