### PR TITLE
Properly support escaping newlines in CEF message

### DIFF
--- a/src/main/java/com/github/jcustenborder/cef/CEFParserImpl.java
+++ b/src/main/java/com/github/jcustenborder/cef/CEFParserImpl.java
@@ -176,6 +176,7 @@ class CEFParserImpl implements CEFParser {
 
     final List<String> extensionParts = parts.subList(7, parts.size());
     final String extension = Joiner.on('|').join(extensionParts)
+        .replace("\\r", "\r")
         .replace("\\n", "\n")
         .replace("\\=", "=");
     log.trace("parse() - extension = '{}'", extension);

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message0009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message0009.json
@@ -1,0 +1,16 @@
+{
+  "input": "CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected": {
+    "cefVersion": 0,
+    "deviceVendor": "security",
+    "deviceProduct": "threatmanager",
+    "deviceVersion": "1.0",
+    "deviceEventClassId": "100",
+    "name": "Detected a threat. No action needed.",
+    "severity": "10",
+    "extensions": {
+      "src": "10.0.0.1",
+      "msg": "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message1009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message1009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "1493738863000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1493738863000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message2009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message2009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "May 02 15:27:43.000 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1493738863000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message3009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message3009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "May 02 15:27:43.000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1493738863000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message4009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message4009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "May 02 15:27:43 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1493738863000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message5009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message5009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "May 02 15:27:43 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1493738863000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message6009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message6009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "May 02 2017 15:27:43.000 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1493738863000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message7009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message7009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "May 02 2017 15:27:43.000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1493738863000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message8009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message8009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "May 02 2017 15:27:43 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1493738863000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message9009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message9009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "May 02 2017 15:27:43 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1493738863000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}


### PR DESCRIPTION
The ArcSight Common Event Format (CEF) specification version 24 says:

> Multi-line fields can be sent by CEF by encoding the newline character as \n or \r. Note that multiple lines are only allowed in the value part of the extensions. For example:
>
> Sep 19 08:26:10 host CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\n No action needed.