### PR TITLE
Allow more lenient prefix of CEF messages

### DIFF
--- a/src/main/java/com/github/jcustenborder/cef/CEFParserImpl.java
+++ b/src/main/java/com/github/jcustenborder/cef/CEFParserImpl.java
@@ -38,7 +38,7 @@ import java.util.regex.Pattern;
 class CEFParserImpl implements CEFParser {
   final static TimeZone TIME_ZONE = TimeZone.getTimeZone("UTC");
   private static final Logger log = LoggerFactory.getLogger(CEFParserImpl.class);
-  private static final Pattern PATTERN_CEF_PREFIX = Pattern.compile("^((?<timestamp>.+)\\s+(?<host>\\S+)\\s+)(?<cs0>CEF:\\d+)|^(?<cs1>CEF:\\d+)");
+  private static final Pattern PATTERN_CEF_PREFIX = Pattern.compile("^((?<timestamp>.+)\\s+(?<host>\\S+)\\s+).*?(?<cs0>CEF:\\d+)|^.*?(?<cs1>CEF:\\d+)");
   private static final Pattern PATTERN_CEF_MAIN = Pattern.compile("(?<!\\\\)\\|");
   private static final Pattern PATTERN_EXTENSION = Pattern.compile("(\\w+)=");
   private static final List<String> DATE_FORMATS = Arrays.asList(

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message0011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message0011.json
@@ -1,0 +1,16 @@
+{
+  "input": "ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected": {
+    "cefVersion": 0,
+    "deviceVendor": "F5",
+    "deviceProduct": "ASM",
+    "deviceVersion": "10.1.0",
+    "deviceEventClassId": "Illegal query string length",
+    "name": "Illegal query string length",
+    "severity": "6",
+    "extensions": {
+      "dvchost": "3600.lab.asm.f5net.com",
+      "dvc": "172.30.0.20"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message1011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message1011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "1506351213000 hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506351213000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message2011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message2011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "Sep 25 14:53:33.000 UTC hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506351213000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message3011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message3011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "Sep 25 14:53:33.000 hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506351213000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message4011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message4011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "Sep 25 14:53:33 UTC hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506351213000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message5011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message5011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "Sep 25 14:53:33 hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506351213000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message6011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message6011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "Sep 25 2017 14:53:33.000 UTC hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506351213000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message7011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message7011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "Sep 25 2017 14:53:33.000 hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506351213000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message8011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message8011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "Sep 25 2017 14:53:33 UTC hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506351213000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message9011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message9011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "Sep 25 2017 14:53:33 hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506351213000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}


### PR DESCRIPTION
Some devices, such as the F5 Networks BIG-IP Application Security Manager (ASM), add a custom prefix to the CEF messages.

This PR makes the CEF prefix pattern more lenient to include these custom prefixes.

See https://www.f5.com/images/solution-center/arcsight-f5-asm-certified-cef-onfiguration-guide.pdf#page=7 for examples.