### PR TITLE
Properly support escaping equal signs in CEF message

### DIFF
--- a/src/main/java/com/github/jcustenborder/cef/CEFParserImpl.java
+++ b/src/main/java/com/github/jcustenborder/cef/CEFParserImpl.java
@@ -175,9 +175,7 @@ class CEFParserImpl implements CEFParser {
     }
 
     final List<String> extensionParts = parts.subList(7, parts.size());
-    final String extension = Joiner.on('|').join(extensionParts)
-        .replace("\\n", "\n")
-        .replace("\\=", "=");
+    final String extension = Joiner.on('|').join(extensionParts);
     log.trace("parse() - extension = '{}'", extension);
     Map<String, String> extensions = new LinkedHashMap<>(100);
     Matcher matcher = PATTERN_EXTENSION.matcher(extension);
@@ -190,7 +188,7 @@ class CEFParserImpl implements CEFParser {
       log.trace("parse() - matcher.start() = {}, matcher.end() = {}", matcher.start(), matcher.end());
 
       if (lastEnd > -1) {
-        value = extension.substring(lastEnd, matcher.start()).trim();
+        value = sanitizeValue(extension.substring(lastEnd, matcher.start()));
         extensions.put(key, value);
         log.trace("parse() - key='{}' value='{}'", key, value);
       }
@@ -201,7 +199,7 @@ class CEFParserImpl implements CEFParser {
     }
 
     if (lastStart > -1 && !extensions.containsKey(key)) {
-      value = extension.substring(lastEnd).trim();
+      value = sanitizeValue(extension.substring(lastEnd));
       extensions.put(key, value);
       log.trace("parse() - key='{}' value='{}'", key, value);
     }
@@ -210,5 +208,9 @@ class CEFParserImpl implements CEFParser {
     return builder.build();
   }
 
-
+  private String sanitizeValue(String value) {
+    return value.trim()
+        .replace("\\n", "\n")
+        .replace("\\=", "=");
+  }
 }

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message0010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message0010.json
@@ -1,0 +1,16 @@
+{
+  "input": "CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected": {
+    "cefVersion": 0,
+    "deviceVendor": "security",
+    "deviceProduct": "threatmanager",
+    "deviceVersion": "1.0",
+    "deviceEventClassId": "100",
+    "name": "Detected a threat. No action needed.",
+    "severity": "10",
+    "extensions": {
+      "src": "10.0.0.1",
+      "msg": "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message1010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message1010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "1506346575000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506346575000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message2010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message2010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "Sep 25 13:36:15.000 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506346575000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message3010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message3010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "Sep 25 13:36:15.000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506346575000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message4010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message4010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "Sep 25 13:36:15 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506346575000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message5010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message5010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "Sep 25 13:36:15 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506346575000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message6010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message6010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "Sep 25 2017 13:36:15.000 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506346575000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message7010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message7010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "Sep 25 2017 13:36:15.000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506346575000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message8010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message8010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "Sep 25 2017 13:36:15 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506346575000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message9010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message9010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "Sep 25 2017 13:36:15 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506346575000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}


### PR DESCRIPTION
The ArcSight Common Event Format (CEF) specification version 24 says:

> If an equal sign (=) is used in the extensions, it has to be escaped with a backslash (\). Equal signs in the header need no escaping. For example:
>
> Sep 19 08:26:10 host CEF:0|security|threatmanager|1.0|100|detected a = in message|10|src=10.0.0.1 act=blocked a \= dst=1.1.1.1