### PR TITLE
Add more (ISO-8601-like) datetime formats

### DIFF
--- a/src/main/java/com/github/jcustenborder/cef/CEFParserImpl.java
+++ b/src/main/java/com/github/jcustenborder/cef/CEFParserImpl.java
@@ -49,7 +49,17 @@ class CEFParserImpl implements CEFParser {
       "MMM dd HH:mm:ss.SSS zzz",
       "MMM dd HH:mm:ss.SSS",
       "MMM dd HH:mm:ss zzz",
-      "MMM dd HH:mm:ss"
+      "MMM dd HH:mm:ss",
+      "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
+      "yyyy-MM-dd'T'HH:mm:ssZ",
+      "yyyy-MM-dd'T'HH:mm:ss.SSS zzz",
+      "yyyy-MM-dd'T'HH:mm:ss zzz",
+      "yyyy-MM-dd'T'HH:mm:ss.SSS ZZZ",
+      "yyyy-MM-dd'T'HH:mm:ss ZZZ",
+      "yyyy-MM-dd'T'HH:mm:ss.SSS XXX",
+      "yyyy-MM-dd'T'HH:mm:ss XXX",
+      "yyyy-MM-dd'T'HH:mm:ssXXX",
+      "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
   );
   final MessageFactory messageFactory;
 

--- a/src/test/java/com/github/jcustenborder/cef/ParserImplTest.java
+++ b/src/test/java/com/github/jcustenborder/cef/ParserImplTest.java
@@ -86,7 +86,17 @@ public class ParserImplTest {
         "MMM dd yyyy HH:mm:ss.SSS zzz",
         "MMM dd yyyy HH:mm:ss.SSS",
         "MMM dd yyyy HH:mm:ss zzz",
-        "MMM dd yyyy HH:mm:ss"
+        "MMM dd yyyy HH:mm:ss",
+        "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
+        "yyyy-MM-dd'T'HH:mm:ssZ",
+        "yyyy-MM-dd'T'HH:mm:ss.SSS zzz",
+        "yyyy-MM-dd'T'HH:mm:ss zzz",
+        "yyyy-MM-dd'T'HH:mm:ss.SSS ZZZ",
+        "yyyy-MM-dd'T'HH:mm:ss ZZZ",
+        "yyyy-MM-dd'T'HH:mm:ss.SSS XXX",
+        "yyyy-MM-dd'T'HH:mm:ss XXX",
+        "yyyy-MM-dd'T'HH:mm:ssXXX",
+        "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
     );
 
     for (Map.Entry<Integer, TestCase> kvp : testcaseByNumber.entrySet()) {

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message10000.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message10000.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000+0000 hostname.example.com CEF:0|Security|threatmanager|1.0|100|worm successfully stopped|10|src=10.0.0.1 dst=2.1.2.2 spt=1232",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "worm successfully stopped",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "dst" : "2.1.2.2",
+      "spt" : "1232"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message10001.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message10001.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000+0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\| in message|10|src=10.0.0.1 act=blocked a | dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a | in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a |",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message10002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message10002.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000+0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a \\ in packet",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a \\",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message10003.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message10003.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000+0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a = in message|10|src=10.0.0.1 act=blocked a \\= dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a = in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a =",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message10004.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message10004.json
@@ -1,0 +1,28 @@
+{
+  "input" : "2017-09-26T08:40:26.000+0000 hostname.example.com CEF:0|ArcSight|Logger|5.0.0.5355.2|sensor:115|Logger Internal Event|1|cat=/Monitor/Sensor/Fan5 cs2=Current Value cnt=1 dvc=10.0.0.1 cs3=Ok cs1=null type=0 cs1Label=unit rt=1305034099211 cs3Label=Status cn1Label=value cs2Label=timeframe",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "ArcSight",
+    "deviceProduct" : "Logger",
+    "deviceVersion" : "5.0.0.5355.2",
+    "deviceEventClassId" : "sensor:115",
+    "name" : "Logger Internal Event",
+    "severity" : "1",
+    "extensions" : {
+      "cat" : "/Monitor/Sensor/Fan5",
+      "cs2" : "Current Value",
+      "cnt" : "1",
+      "dvc" : "10.0.0.1",
+      "cs3" : "Ok",
+      "cs1" : "null",
+      "type" : "0",
+      "cs1Label" : "unit",
+      "rt" : "1305034099211",
+      "cs3Label" : "Status",
+      "cn1Label" : "value",
+      "cs2Label" : "timeframe"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message10005.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message10005.json
@@ -1,0 +1,22 @@
+{
+  "input" : "2017-09-26T08:40:26.000+0000 hostname.example.com CEF:0|Trend Micro Inc.|OSSEC HIDS|v2.5.1|5302|User missed the password to change UID to root.|9|dvc=ubuntusvr cs2=ubuntusvr->/var/log/auth.log cs2Label=Location src= suser=root msg=May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Trend Micro Inc.",
+    "deviceProduct" : "OSSEC HIDS",
+    "deviceVersion" : "v2.5.1",
+    "deviceEventClassId" : "5302",
+    "name" : "User missed the password to change UID to root.",
+    "severity" : "9",
+    "extensions" : {
+      "dvc" : "ubuntusvr",
+      "cs2" : "ubuntusvr->/var/log/auth.log",
+      "cs2Label" : "Location",
+      "src" : "",
+      "suser" : "root",
+      "msg" : "May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message10006.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message10006.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000+0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\n No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\n No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message10007.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message10007.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26.000+0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message10008.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message10008.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26.000+0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message10009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message10009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000+0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message10010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message10010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000+0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message10011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message10011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000+0000 hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message11000.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message11000.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26+0000 hostname.example.com CEF:0|Security|threatmanager|1.0|100|worm successfully stopped|10|src=10.0.0.1 dst=2.1.2.2 spt=1232",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "worm successfully stopped",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "dst" : "2.1.2.2",
+      "spt" : "1232"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message11001.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message11001.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26+0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\| in message|10|src=10.0.0.1 act=blocked a | dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a | in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a |",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message11002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message11002.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26+0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a \\ in packet",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a \\",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message11003.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message11003.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26+0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a = in message|10|src=10.0.0.1 act=blocked a \\= dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a = in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a =",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message11004.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message11004.json
@@ -1,0 +1,28 @@
+{
+  "input" : "2017-09-26T08:40:26+0000 hostname.example.com CEF:0|ArcSight|Logger|5.0.0.5355.2|sensor:115|Logger Internal Event|1|cat=/Monitor/Sensor/Fan5 cs2=Current Value cnt=1 dvc=10.0.0.1 cs3=Ok cs1=null type=0 cs1Label=unit rt=1305034099211 cs3Label=Status cn1Label=value cs2Label=timeframe",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "ArcSight",
+    "deviceProduct" : "Logger",
+    "deviceVersion" : "5.0.0.5355.2",
+    "deviceEventClassId" : "sensor:115",
+    "name" : "Logger Internal Event",
+    "severity" : "1",
+    "extensions" : {
+      "cat" : "/Monitor/Sensor/Fan5",
+      "cs2" : "Current Value",
+      "cnt" : "1",
+      "dvc" : "10.0.0.1",
+      "cs3" : "Ok",
+      "cs1" : "null",
+      "type" : "0",
+      "cs1Label" : "unit",
+      "rt" : "1305034099211",
+      "cs3Label" : "Status",
+      "cn1Label" : "value",
+      "cs2Label" : "timeframe"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message11005.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message11005.json
@@ -1,0 +1,22 @@
+{
+  "input" : "2017-09-26T08:40:26+0000 hostname.example.com CEF:0|Trend Micro Inc.|OSSEC HIDS|v2.5.1|5302|User missed the password to change UID to root.|9|dvc=ubuntusvr cs2=ubuntusvr->/var/log/auth.log cs2Label=Location src= suser=root msg=May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Trend Micro Inc.",
+    "deviceProduct" : "OSSEC HIDS",
+    "deviceVersion" : "v2.5.1",
+    "deviceEventClassId" : "5302",
+    "name" : "User missed the password to change UID to root.",
+    "severity" : "9",
+    "extensions" : {
+      "dvc" : "ubuntusvr",
+      "cs2" : "ubuntusvr->/var/log/auth.log",
+      "cs2Label" : "Location",
+      "src" : "",
+      "suser" : "root",
+      "msg" : "May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message11006.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message11006.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26+0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\n No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\n No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message11007.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message11007.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26+0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message11008.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message11008.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26+0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message11009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message11009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26+0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message11010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message11010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26+0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message11011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message11011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26+0000 hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message12000.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message12000.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000 UTC hostname.example.com CEF:0|Security|threatmanager|1.0|100|worm successfully stopped|10|src=10.0.0.1 dst=2.1.2.2 spt=1232",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "worm successfully stopped",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "dst" : "2.1.2.2",
+      "spt" : "1232"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message12001.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message12001.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\| in message|10|src=10.0.0.1 act=blocked a | dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a | in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a |",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message12002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message12002.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a \\ in packet",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a \\",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message12003.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message12003.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a = in message|10|src=10.0.0.1 act=blocked a \\= dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a = in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a =",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message12004.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message12004.json
@@ -1,0 +1,28 @@
+{
+  "input" : "2017-09-26T08:40:26.000 UTC hostname.example.com CEF:0|ArcSight|Logger|5.0.0.5355.2|sensor:115|Logger Internal Event|1|cat=/Monitor/Sensor/Fan5 cs2=Current Value cnt=1 dvc=10.0.0.1 cs3=Ok cs1=null type=0 cs1Label=unit rt=1305034099211 cs3Label=Status cn1Label=value cs2Label=timeframe",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "ArcSight",
+    "deviceProduct" : "Logger",
+    "deviceVersion" : "5.0.0.5355.2",
+    "deviceEventClassId" : "sensor:115",
+    "name" : "Logger Internal Event",
+    "severity" : "1",
+    "extensions" : {
+      "cat" : "/Monitor/Sensor/Fan5",
+      "cs2" : "Current Value",
+      "cnt" : "1",
+      "dvc" : "10.0.0.1",
+      "cs3" : "Ok",
+      "cs1" : "null",
+      "type" : "0",
+      "cs1Label" : "unit",
+      "rt" : "1305034099211",
+      "cs3Label" : "Status",
+      "cn1Label" : "value",
+      "cs2Label" : "timeframe"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message12005.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message12005.json
@@ -1,0 +1,22 @@
+{
+  "input" : "2017-09-26T08:40:26.000 UTC hostname.example.com CEF:0|Trend Micro Inc.|OSSEC HIDS|v2.5.1|5302|User missed the password to change UID to root.|9|dvc=ubuntusvr cs2=ubuntusvr->/var/log/auth.log cs2Label=Location src= suser=root msg=May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Trend Micro Inc.",
+    "deviceProduct" : "OSSEC HIDS",
+    "deviceVersion" : "v2.5.1",
+    "deviceEventClassId" : "5302",
+    "name" : "User missed the password to change UID to root.",
+    "severity" : "9",
+    "extensions" : {
+      "dvc" : "ubuntusvr",
+      "cs2" : "ubuntusvr->/var/log/auth.log",
+      "cs2Label" : "Location",
+      "src" : "",
+      "suser" : "root",
+      "msg" : "May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message12006.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message12006.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\n No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\n No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message12007.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message12007.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26.000 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message12008.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message12008.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26.000 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message12009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message12009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message12010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message12010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message12011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message12011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000 UTC hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message13000.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message13000.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26 UTC hostname.example.com CEF:0|Security|threatmanager|1.0|100|worm successfully stopped|10|src=10.0.0.1 dst=2.1.2.2 spt=1232",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "worm successfully stopped",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "dst" : "2.1.2.2",
+      "spt" : "1232"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message13001.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message13001.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\| in message|10|src=10.0.0.1 act=blocked a | dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a | in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a |",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message13002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message13002.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a \\ in packet",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a \\",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message13003.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message13003.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a = in message|10|src=10.0.0.1 act=blocked a \\= dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a = in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a =",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message13004.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message13004.json
@@ -1,0 +1,28 @@
+{
+  "input" : "2017-09-26T08:40:26 UTC hostname.example.com CEF:0|ArcSight|Logger|5.0.0.5355.2|sensor:115|Logger Internal Event|1|cat=/Monitor/Sensor/Fan5 cs2=Current Value cnt=1 dvc=10.0.0.1 cs3=Ok cs1=null type=0 cs1Label=unit rt=1305034099211 cs3Label=Status cn1Label=value cs2Label=timeframe",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "ArcSight",
+    "deviceProduct" : "Logger",
+    "deviceVersion" : "5.0.0.5355.2",
+    "deviceEventClassId" : "sensor:115",
+    "name" : "Logger Internal Event",
+    "severity" : "1",
+    "extensions" : {
+      "cat" : "/Monitor/Sensor/Fan5",
+      "cs2" : "Current Value",
+      "cnt" : "1",
+      "dvc" : "10.0.0.1",
+      "cs3" : "Ok",
+      "cs1" : "null",
+      "type" : "0",
+      "cs1Label" : "unit",
+      "rt" : "1305034099211",
+      "cs3Label" : "Status",
+      "cn1Label" : "value",
+      "cs2Label" : "timeframe"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message13005.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message13005.json
@@ -1,0 +1,22 @@
+{
+  "input" : "2017-09-26T08:40:26 UTC hostname.example.com CEF:0|Trend Micro Inc.|OSSEC HIDS|v2.5.1|5302|User missed the password to change UID to root.|9|dvc=ubuntusvr cs2=ubuntusvr->/var/log/auth.log cs2Label=Location src= suser=root msg=May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Trend Micro Inc.",
+    "deviceProduct" : "OSSEC HIDS",
+    "deviceVersion" : "v2.5.1",
+    "deviceEventClassId" : "5302",
+    "name" : "User missed the password to change UID to root.",
+    "severity" : "9",
+    "extensions" : {
+      "dvc" : "ubuntusvr",
+      "cs2" : "ubuntusvr->/var/log/auth.log",
+      "cs2Label" : "Location",
+      "src" : "",
+      "suser" : "root",
+      "msg" : "May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message13006.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message13006.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\n No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\n No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message13007.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message13007.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message13008.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message13008.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message13009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message13009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message13010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message13010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26 UTC hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message13011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message13011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26 UTC hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message14000.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message14000.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000 +0000 hostname.example.com CEF:0|Security|threatmanager|1.0|100|worm successfully stopped|10|src=10.0.0.1 dst=2.1.2.2 spt=1232",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "worm successfully stopped",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "dst" : "2.1.2.2",
+      "spt" : "1232"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message14001.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message14001.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000 +0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\| in message|10|src=10.0.0.1 act=blocked a | dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a | in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a |",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message14002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message14002.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000 +0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a \\ in packet",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a \\",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message14003.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message14003.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000 +0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a = in message|10|src=10.0.0.1 act=blocked a \\= dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a = in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a =",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message14004.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message14004.json
@@ -1,0 +1,28 @@
+{
+  "input" : "2017-09-26T08:40:26.000 +0000 hostname.example.com CEF:0|ArcSight|Logger|5.0.0.5355.2|sensor:115|Logger Internal Event|1|cat=/Monitor/Sensor/Fan5 cs2=Current Value cnt=1 dvc=10.0.0.1 cs3=Ok cs1=null type=0 cs1Label=unit rt=1305034099211 cs3Label=Status cn1Label=value cs2Label=timeframe",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "ArcSight",
+    "deviceProduct" : "Logger",
+    "deviceVersion" : "5.0.0.5355.2",
+    "deviceEventClassId" : "sensor:115",
+    "name" : "Logger Internal Event",
+    "severity" : "1",
+    "extensions" : {
+      "cat" : "/Monitor/Sensor/Fan5",
+      "cs2" : "Current Value",
+      "cnt" : "1",
+      "dvc" : "10.0.0.1",
+      "cs3" : "Ok",
+      "cs1" : "null",
+      "type" : "0",
+      "cs1Label" : "unit",
+      "rt" : "1305034099211",
+      "cs3Label" : "Status",
+      "cn1Label" : "value",
+      "cs2Label" : "timeframe"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message14005.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message14005.json
@@ -1,0 +1,22 @@
+{
+  "input" : "2017-09-26T08:40:26.000 +0000 hostname.example.com CEF:0|Trend Micro Inc.|OSSEC HIDS|v2.5.1|5302|User missed the password to change UID to root.|9|dvc=ubuntusvr cs2=ubuntusvr->/var/log/auth.log cs2Label=Location src= suser=root msg=May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Trend Micro Inc.",
+    "deviceProduct" : "OSSEC HIDS",
+    "deviceVersion" : "v2.5.1",
+    "deviceEventClassId" : "5302",
+    "name" : "User missed the password to change UID to root.",
+    "severity" : "9",
+    "extensions" : {
+      "dvc" : "ubuntusvr",
+      "cs2" : "ubuntusvr->/var/log/auth.log",
+      "cs2Label" : "Location",
+      "src" : "",
+      "suser" : "root",
+      "msg" : "May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message14006.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message14006.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000 +0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\n No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\n No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message14007.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message14007.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26.000 +0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message14008.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message14008.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26.000 +0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message14009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message14009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000 +0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message14010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message14010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000 +0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message14011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message14011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000 +0000 hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message15000.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message15000.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26 +0000 hostname.example.com CEF:0|Security|threatmanager|1.0|100|worm successfully stopped|10|src=10.0.0.1 dst=2.1.2.2 spt=1232",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "worm successfully stopped",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "dst" : "2.1.2.2",
+      "spt" : "1232"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message15001.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message15001.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26 +0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\| in message|10|src=10.0.0.1 act=blocked a | dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a | in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a |",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message15002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message15002.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26 +0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a \\ in packet",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a \\",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message15003.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message15003.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26 +0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a = in message|10|src=10.0.0.1 act=blocked a \\= dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a = in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a =",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message15004.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message15004.json
@@ -1,0 +1,28 @@
+{
+  "input" : "2017-09-26T08:40:26 +0000 hostname.example.com CEF:0|ArcSight|Logger|5.0.0.5355.2|sensor:115|Logger Internal Event|1|cat=/Monitor/Sensor/Fan5 cs2=Current Value cnt=1 dvc=10.0.0.1 cs3=Ok cs1=null type=0 cs1Label=unit rt=1305034099211 cs3Label=Status cn1Label=value cs2Label=timeframe",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "ArcSight",
+    "deviceProduct" : "Logger",
+    "deviceVersion" : "5.0.0.5355.2",
+    "deviceEventClassId" : "sensor:115",
+    "name" : "Logger Internal Event",
+    "severity" : "1",
+    "extensions" : {
+      "cat" : "/Monitor/Sensor/Fan5",
+      "cs2" : "Current Value",
+      "cnt" : "1",
+      "dvc" : "10.0.0.1",
+      "cs3" : "Ok",
+      "cs1" : "null",
+      "type" : "0",
+      "cs1Label" : "unit",
+      "rt" : "1305034099211",
+      "cs3Label" : "Status",
+      "cn1Label" : "value",
+      "cs2Label" : "timeframe"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message15005.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message15005.json
@@ -1,0 +1,22 @@
+{
+  "input" : "2017-09-26T08:40:26 +0000 hostname.example.com CEF:0|Trend Micro Inc.|OSSEC HIDS|v2.5.1|5302|User missed the password to change UID to root.|9|dvc=ubuntusvr cs2=ubuntusvr->/var/log/auth.log cs2Label=Location src= suser=root msg=May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Trend Micro Inc.",
+    "deviceProduct" : "OSSEC HIDS",
+    "deviceVersion" : "v2.5.1",
+    "deviceEventClassId" : "5302",
+    "name" : "User missed the password to change UID to root.",
+    "severity" : "9",
+    "extensions" : {
+      "dvc" : "ubuntusvr",
+      "cs2" : "ubuntusvr->/var/log/auth.log",
+      "cs2Label" : "Location",
+      "src" : "",
+      "suser" : "root",
+      "msg" : "May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message15006.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message15006.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26 +0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\n No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\n No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message15007.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message15007.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26 +0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message15008.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message15008.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26 +0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message15009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message15009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26 +0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message15010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message15010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26 +0000 hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message15011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message15011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26 +0000 hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message16000.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message16000.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000 Z hostname.example.com CEF:0|Security|threatmanager|1.0|100|worm successfully stopped|10|src=10.0.0.1 dst=2.1.2.2 spt=1232",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "worm successfully stopped",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "dst" : "2.1.2.2",
+      "spt" : "1232"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message16001.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message16001.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000 Z hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\| in message|10|src=10.0.0.1 act=blocked a | dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a | in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a |",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message16002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message16002.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000 Z hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a \\ in packet",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a \\",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message16003.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message16003.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000 Z hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a = in message|10|src=10.0.0.1 act=blocked a \\= dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a = in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a =",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message16004.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message16004.json
@@ -1,0 +1,28 @@
+{
+  "input" : "2017-09-26T08:40:26.000 Z hostname.example.com CEF:0|ArcSight|Logger|5.0.0.5355.2|sensor:115|Logger Internal Event|1|cat=/Monitor/Sensor/Fan5 cs2=Current Value cnt=1 dvc=10.0.0.1 cs3=Ok cs1=null type=0 cs1Label=unit rt=1305034099211 cs3Label=Status cn1Label=value cs2Label=timeframe",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "ArcSight",
+    "deviceProduct" : "Logger",
+    "deviceVersion" : "5.0.0.5355.2",
+    "deviceEventClassId" : "sensor:115",
+    "name" : "Logger Internal Event",
+    "severity" : "1",
+    "extensions" : {
+      "cat" : "/Monitor/Sensor/Fan5",
+      "cs2" : "Current Value",
+      "cnt" : "1",
+      "dvc" : "10.0.0.1",
+      "cs3" : "Ok",
+      "cs1" : "null",
+      "type" : "0",
+      "cs1Label" : "unit",
+      "rt" : "1305034099211",
+      "cs3Label" : "Status",
+      "cn1Label" : "value",
+      "cs2Label" : "timeframe"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message16005.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message16005.json
@@ -1,0 +1,22 @@
+{
+  "input" : "2017-09-26T08:40:26.000 Z hostname.example.com CEF:0|Trend Micro Inc.|OSSEC HIDS|v2.5.1|5302|User missed the password to change UID to root.|9|dvc=ubuntusvr cs2=ubuntusvr->/var/log/auth.log cs2Label=Location src= suser=root msg=May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Trend Micro Inc.",
+    "deviceProduct" : "OSSEC HIDS",
+    "deviceVersion" : "v2.5.1",
+    "deviceEventClassId" : "5302",
+    "name" : "User missed the password to change UID to root.",
+    "severity" : "9",
+    "extensions" : {
+      "dvc" : "ubuntusvr",
+      "cs2" : "ubuntusvr->/var/log/auth.log",
+      "cs2Label" : "Location",
+      "src" : "",
+      "suser" : "root",
+      "msg" : "May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message16006.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message16006.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000 Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\n No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\n No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message16007.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message16007.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26.000 Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message16008.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message16008.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26.000 Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message16009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message16009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000 Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message16010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message16010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000 Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message16011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message16011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000 Z hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message17000.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message17000.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26 Z hostname.example.com CEF:0|Security|threatmanager|1.0|100|worm successfully stopped|10|src=10.0.0.1 dst=2.1.2.2 spt=1232",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "worm successfully stopped",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "dst" : "2.1.2.2",
+      "spt" : "1232"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message17001.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message17001.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26 Z hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\| in message|10|src=10.0.0.1 act=blocked a | dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a | in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a |",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message17002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message17002.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26 Z hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a \\ in packet",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a \\",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message17003.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message17003.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26 Z hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a = in message|10|src=10.0.0.1 act=blocked a \\= dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a = in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a =",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message17004.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message17004.json
@@ -1,0 +1,28 @@
+{
+  "input" : "2017-09-26T08:40:26 Z hostname.example.com CEF:0|ArcSight|Logger|5.0.0.5355.2|sensor:115|Logger Internal Event|1|cat=/Monitor/Sensor/Fan5 cs2=Current Value cnt=1 dvc=10.0.0.1 cs3=Ok cs1=null type=0 cs1Label=unit rt=1305034099211 cs3Label=Status cn1Label=value cs2Label=timeframe",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "ArcSight",
+    "deviceProduct" : "Logger",
+    "deviceVersion" : "5.0.0.5355.2",
+    "deviceEventClassId" : "sensor:115",
+    "name" : "Logger Internal Event",
+    "severity" : "1",
+    "extensions" : {
+      "cat" : "/Monitor/Sensor/Fan5",
+      "cs2" : "Current Value",
+      "cnt" : "1",
+      "dvc" : "10.0.0.1",
+      "cs3" : "Ok",
+      "cs1" : "null",
+      "type" : "0",
+      "cs1Label" : "unit",
+      "rt" : "1305034099211",
+      "cs3Label" : "Status",
+      "cn1Label" : "value",
+      "cs2Label" : "timeframe"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message17005.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message17005.json
@@ -1,0 +1,22 @@
+{
+  "input" : "2017-09-26T08:40:26 Z hostname.example.com CEF:0|Trend Micro Inc.|OSSEC HIDS|v2.5.1|5302|User missed the password to change UID to root.|9|dvc=ubuntusvr cs2=ubuntusvr->/var/log/auth.log cs2Label=Location src= suser=root msg=May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Trend Micro Inc.",
+    "deviceProduct" : "OSSEC HIDS",
+    "deviceVersion" : "v2.5.1",
+    "deviceEventClassId" : "5302",
+    "name" : "User missed the password to change UID to root.",
+    "severity" : "9",
+    "extensions" : {
+      "dvc" : "ubuntusvr",
+      "cs2" : "ubuntusvr->/var/log/auth.log",
+      "cs2Label" : "Location",
+      "src" : "",
+      "suser" : "root",
+      "msg" : "May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message17006.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message17006.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26 Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\n No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\n No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message17007.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message17007.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26 Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message17008.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message17008.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26 Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message17009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message17009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26 Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message17010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message17010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26 Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message17011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message17011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26 Z hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message18000.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message18000.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26Z hostname.example.com CEF:0|Security|threatmanager|1.0|100|worm successfully stopped|10|src=10.0.0.1 dst=2.1.2.2 spt=1232",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "worm successfully stopped",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "dst" : "2.1.2.2",
+      "spt" : "1232"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message18001.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message18001.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26Z hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\| in message|10|src=10.0.0.1 act=blocked a | dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a | in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a |",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message18002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message18002.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26Z hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a \\ in packet",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a \\",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message18003.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message18003.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26Z hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a = in message|10|src=10.0.0.1 act=blocked a \\= dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a = in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a =",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message18004.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message18004.json
@@ -1,0 +1,28 @@
+{
+  "input" : "2017-09-26T08:40:26Z hostname.example.com CEF:0|ArcSight|Logger|5.0.0.5355.2|sensor:115|Logger Internal Event|1|cat=/Monitor/Sensor/Fan5 cs2=Current Value cnt=1 dvc=10.0.0.1 cs3=Ok cs1=null type=0 cs1Label=unit rt=1305034099211 cs3Label=Status cn1Label=value cs2Label=timeframe",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "ArcSight",
+    "deviceProduct" : "Logger",
+    "deviceVersion" : "5.0.0.5355.2",
+    "deviceEventClassId" : "sensor:115",
+    "name" : "Logger Internal Event",
+    "severity" : "1",
+    "extensions" : {
+      "cat" : "/Monitor/Sensor/Fan5",
+      "cs2" : "Current Value",
+      "cnt" : "1",
+      "dvc" : "10.0.0.1",
+      "cs3" : "Ok",
+      "cs1" : "null",
+      "type" : "0",
+      "cs1Label" : "unit",
+      "rt" : "1305034099211",
+      "cs3Label" : "Status",
+      "cn1Label" : "value",
+      "cs2Label" : "timeframe"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message18005.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message18005.json
@@ -1,0 +1,22 @@
+{
+  "input" : "2017-09-26T08:40:26Z hostname.example.com CEF:0|Trend Micro Inc.|OSSEC HIDS|v2.5.1|5302|User missed the password to change UID to root.|9|dvc=ubuntusvr cs2=ubuntusvr->/var/log/auth.log cs2Label=Location src= suser=root msg=May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Trend Micro Inc.",
+    "deviceProduct" : "OSSEC HIDS",
+    "deviceVersion" : "v2.5.1",
+    "deviceEventClassId" : "5302",
+    "name" : "User missed the password to change UID to root.",
+    "severity" : "9",
+    "extensions" : {
+      "dvc" : "ubuntusvr",
+      "cs2" : "ubuntusvr->/var/log/auth.log",
+      "cs2Label" : "Location",
+      "src" : "",
+      "suser" : "root",
+      "msg" : "May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message18006.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message18006.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\n No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\n No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message18007.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message18007.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message18008.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message18008.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message18009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message18009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message18010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message18010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message18011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message18011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26Z hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message19000.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message19000.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000Z hostname.example.com CEF:0|Security|threatmanager|1.0|100|worm successfully stopped|10|src=10.0.0.1 dst=2.1.2.2 spt=1232",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "worm successfully stopped",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "dst" : "2.1.2.2",
+      "spt" : "1232"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message19001.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message19001.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000Z hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\| in message|10|src=10.0.0.1 act=blocked a | dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a | in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a |",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message19002.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message19002.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000Z hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 act=blocked a \\\\ dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a \\ in packet",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a \\",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message19003.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message19003.json
@@ -1,0 +1,19 @@
+{
+  "input" : "2017-09-26T08:40:26.000Z hostname.example.com CEF:0|security|threatmanager|1.0|100|detected a = in message|10|src=10.0.0.1 act=blocked a \\= dst=1.1.1.1",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "detected a = in message",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "act" : "blocked a =",
+      "dst" : "1.1.1.1"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message19004.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message19004.json
@@ -1,0 +1,28 @@
+{
+  "input" : "2017-09-26T08:40:26.000Z hostname.example.com CEF:0|ArcSight|Logger|5.0.0.5355.2|sensor:115|Logger Internal Event|1|cat=/Monitor/Sensor/Fan5 cs2=Current Value cnt=1 dvc=10.0.0.1 cs3=Ok cs1=null type=0 cs1Label=unit rt=1305034099211 cs3Label=Status cn1Label=value cs2Label=timeframe",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "ArcSight",
+    "deviceProduct" : "Logger",
+    "deviceVersion" : "5.0.0.5355.2",
+    "deviceEventClassId" : "sensor:115",
+    "name" : "Logger Internal Event",
+    "severity" : "1",
+    "extensions" : {
+      "cat" : "/Monitor/Sensor/Fan5",
+      "cs2" : "Current Value",
+      "cnt" : "1",
+      "dvc" : "10.0.0.1",
+      "cs3" : "Ok",
+      "cs1" : "null",
+      "type" : "0",
+      "cs1Label" : "unit",
+      "rt" : "1305034099211",
+      "cs3Label" : "Status",
+      "cn1Label" : "value",
+      "cs2Label" : "timeframe"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message19005.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message19005.json
@@ -1,0 +1,22 @@
+{
+  "input" : "2017-09-26T08:40:26.000Z hostname.example.com CEF:0|Trend Micro Inc.|OSSEC HIDS|v2.5.1|5302|User missed the password to change UID to root.|9|dvc=ubuntusvr cs2=ubuntusvr->/var/log/auth.log cs2Label=Location src= suser=root msg=May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "Trend Micro Inc.",
+    "deviceProduct" : "OSSEC HIDS",
+    "deviceVersion" : "v2.5.1",
+    "deviceEventClassId" : "5302",
+    "name" : "User missed the password to change UID to root.",
+    "severity" : "9",
+    "extensions" : {
+      "dvc" : "ubuntusvr",
+      "cs2" : "ubuntusvr->/var/log/auth.log",
+      "cs2Label" : "Location",
+      "src" : "",
+      "suser" : "root",
+      "msg" : "May 11 21:16:05 ubuntusvr su[24120]: - /dev/pts/1 xavier:root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message19006.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message19006.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\n No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\n No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message19007.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message19007.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26.000Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message19008.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message19008.json
@@ -1,0 +1,15 @@
+{
+  "input" : "2017-09-26T08:40:26.000Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : { }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message19009.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message19009.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=Detected a threat.\\r No action needed.",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "Detected a threat.\r No action needed."
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message19010.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message19010.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000Z hostname.example.com CEF:0|security|threatmanager|1.0|100|Detected a threat. No action needed.|10|src=10.0.0.1 msg=PAM 2 more authentication failures; logname\\= uid\\=0 euid\\=0 tty\\=ssh ruser\\= rhost\\=116.31.116.17 user\\=root",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "security",
+    "deviceProduct" : "threatmanager",
+    "deviceVersion" : "1.0",
+    "deviceEventClassId" : "100",
+    "name" : "Detected a threat. No action needed.",
+    "severity" : "10",
+    "extensions" : {
+      "src" : "10.0.0.1",
+      "msg" : "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17 user=root"
+    }
+  }
+}

--- a/src/test/resources/com/github/jcustenborder/cef/messages/Message19011.json
+++ b/src/test/resources/com/github/jcustenborder/cef/messages/Message19011.json
@@ -1,0 +1,18 @@
+{
+  "input" : "2017-09-26T08:40:26.000Z hostname.example.com ASM:CEF:0|F5|ASM|10.1.0|Illegal query string length|Illegal query string length|6|dvchost=3600.lab.asm.f5net.com dvc=172.30.0.20",
+  "expected" : {
+    "timestamp" : 1506415226000,
+    "host" : "hostname.example.com",
+    "cefVersion" : 0,
+    "deviceVendor" : "F5",
+    "deviceProduct" : "ASM",
+    "deviceVersion" : "10.1.0",
+    "deviceEventClassId" : "Illegal query string length",
+    "name" : "Illegal query string length",
+    "severity" : "6",
+    "extensions" : {
+      "dvchost" : "3600.lab.asm.f5net.com",
+      "dvc" : "172.30.0.20"
+    }
+  }
+}


### PR DESCRIPTION
While not mandated by the specification, it's not uncommon for implementations to use ISO-8601-like timestamps.

This PR adds some more date/time formats to the CEF parser.