### PR TITLE
Modify CEFParserImpl to allow injection of DateParser.

### DIFF
--- a/src/main/java/com/github/jcustenborder/cef/DateParser.java
+++ b/src/main/java/com/github/jcustenborder/cef/DateParser.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright © 2017 Jeremy Custenborder (jcustenborder@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.jcustenborder.cef;
+
+import java.util.Date;
+
+/**
+ * This interface attempts to parse a string containing a date and time.
+ */
+public interface DateParser {
+
+  /**
+   * Attempts to parse supplied <code>dateTime</code> string.
+   * @param timestampText Text representing a valid timestamp
+   * @return The parsed date or <code>null</code> on failure.
+   */
+  Date parseDate(String timestampText);
+
+}

--- a/src/main/java/com/github/jcustenborder/cef/DateParserImpl.java
+++ b/src/main/java/com/github/jcustenborder/cef/DateParserImpl.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright © 2017 Jeremy Custenborder (jcustenborder@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.jcustenborder.cef;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
+import com.google.common.primitives.Longs;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DateParserImpl implements DateParser {
+
+  private static final TimeZone TIME_ZONE = TimeZone.getTimeZone("UTC");
+  private static final List<String> DATE_FORMATS = Arrays.asList(
+      "MMM dd yyyy HH:mm:ss.SSS zzz",
+      "MMM dd yyyy HH:mm:ss.SSS",
+      "MMM dd yyyy HH:mm:ss zzz",
+      "MMM dd yyyy HH:mm:ss",
+      "MMM dd HH:mm:ss.SSS zzz",
+      "MMM dd HH:mm:ss.SSS",
+      "MMM dd HH:mm:ss zzz",
+      "MMM dd HH:mm:ss"
+  );
+  private static final Logger log = LoggerFactory.getLogger(DateParserImpl.class);
+
+  public Date parseDate(String timestampText) {
+    Long longTimestamp = Longs.tryParse(timestampText);
+    if (null != longTimestamp) {
+      log.trace("parse() - Detected timestamp is stored as a long.");
+      return new Date(longTimestamp);
+    }
+
+    log.trace("parse() - Trying to parse the timestamp.");
+    // SimpleDateFormat is not threadsafe so we have to create a new one each time.
+
+    for (String pattern : DATE_FORMATS) {
+      SimpleDateFormat dateFormat = new SimpleDateFormat(pattern);
+      dateFormat.setTimeZone(TIME_ZONE);
+      try {
+        log.trace("parse() - Trying to parse '{}' with format '{}'", timestampText, pattern);
+        Date timestamp = dateFormat.parse(timestampText);
+        final boolean alterYear = !pattern.contains("yyyy");
+
+        if (alterYear) {
+          log.trace("parse() - date format '{}' does not specify the year. Might need to alter the year.", pattern);
+          Calendar calendar = Calendar.getInstance(TIME_ZONE);
+          int thisYear = calendar.get(Calendar.YEAR);
+          calendar.setTime(timestamp);
+          final int year = calendar.get(Calendar.YEAR);
+          if (1970 == year) {
+            log.trace("parse() - altering year from {} to {}", year, thisYear);
+            calendar.set(Calendar.YEAR, thisYear);
+            return calendar.getTime();
+          }
+        }
+
+        return timestamp;
+      } catch (ParseException e) {
+        log.trace("parse() - Could not parse '{}' with '{}'.", timestampText, pattern);
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/com/github/jcustenborder/cef/DateParserImpl.java
+++ b/src/main/java/com/github/jcustenborder/cef/DateParserImpl.java
@@ -43,6 +43,7 @@ public class DateParserImpl implements DateParser {
   );
   private static final Logger log = LoggerFactory.getLogger(DateParserImpl.class);
 
+  @Override
   public Date parseDate(String timestampText) {
     Long longTimestamp = Longs.tryParse(timestampText);
     if (null != longTimestamp) {

--- a/src/test/java/com/github/jcustenborder/cef/MessageAssertions.java
+++ b/src/test/java/com/github/jcustenborder/cef/MessageAssertions.java
@@ -19,12 +19,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.Date;
+
 public class MessageAssertions {
   public static void assertMessage(Message expected, Message actual) {
     if (null == expected) {
       assertNull(actual, "actual should be null.");
     } else {
       assertNotNull(actual, "actual should not be null.");
+    }
+
+    // Force actual year to match the year that the tests were recorded
+    final Date expectedTimestamp = expected.timestamp(), actualTimestamp = actual.timestamp();
+    if (expectedTimestamp != null && actualTimestamp != null
+        && expectedTimestamp.getYear() != actualTimestamp.getYear()) {
+      assertEquals(actualTimestamp.getYear(), new Date().getYear(), "year does not match");
+      actual.timestamp().setYear(expected.timestamp().getYear());
     }
 
     assertEquals(expected.timestamp(), actual.timestamp(), "timestamp() does not match");


### PR DESCRIPTION
Moved date parsing logic into its own class to allow arbitrary dates to be parsed in a backward compatible manner. Reasonable efforts were taken to conform to the style of the existing code.